### PR TITLE
Fix coordinate system mismatch in 3D model viewer

### DIFF
--- a/web/src/components/ModelViewer.tsx
+++ b/web/src/components/ModelViewer.tsx
@@ -6,6 +6,20 @@ import { Loader2, Box, AlertCircle, Layers } from 'lucide-react'
 import * as THREE from 'three'
 import { fetchModelMesh, ModelMesh } from '../api/client'
 
+// Distinct color palette for geological surfaces
+const SURFACE_COLORS = [
+  '#E6B422', // Gold
+  '#2E8B57', // Sea green
+  '#4682B4', // Steel blue
+  '#CD853F', // Peru
+  '#9932CC', // Dark orchid
+  '#20B2AA', // Light sea green
+  '#DC143C', // Crimson
+  '#FF8C00', // Dark orange
+  '#8B4513', // Saddle brown
+  '#6A5ACD', // Slate blue
+]
+
 interface ModelViewerProps {
   modelId: number | null
   onBuildRequest?: () => void
@@ -116,12 +130,12 @@ function ModelScene({ meshData }: { meshData: ModelMesh }) {
 
       {/* Model group */}
       <group ref={groupRef}>
-        {meshData.surfaces.map((surface) => (
+        {meshData.surfaces.map((surface, index) => (
           <SurfaceMesh
             key={surface.surface_id}
             vertices={surface.vertices}
             faces={surface.faces}
-            color={surface.color}
+            color={SURFACE_COLORS[index % SURFACE_COLORS.length]}
           />
         ))}
       </group>
@@ -182,11 +196,11 @@ function SurfaceLegend({ surfaces }: { surfaces: ModelMesh['surfaces'] }) {
         <span>Surfaces</span>
       </div>
       <div className="space-y-1 max-h-32 overflow-y-auto">
-        {surfaces.map((surface) => (
+        {surfaces.map((surface, index) => (
           <div key={surface.surface_id} className="flex items-center gap-2">
             <div
               className="w-3 h-3 rounded-sm flex-shrink-0"
-              style={{ backgroundColor: surface.color }}
+              style={{ backgroundColor: SURFACE_COLORS[index % SURFACE_COLORS.length] }}
             />
             <span className="text-xs text-gray-600 truncate" title={surface.name}>
               {surface.name}


### PR DESCRIPTION
# Fix coordinate system mismatch in 3D model viewer

Closes https://github.com/williamjsdavis/geo-lm/issues/11

## Summary

- Fix Z-up to Y-up coordinate transformation for correct plane orientation
- Add distinct color palette for geological surfaces
- Update legend colors to match 3D visualization

<img width="418" height="578" alt="Screenshot 2026-01-22 at 10 04 28 AM" src="https://github.com/user-attachments/assets/f13ca22a-7957-4702-9ced-97ef25f04dcc" />


## Problem

The 3D model viewer was displaying horizontal geological planes as vertical planes. This was caused by a coordinate system mismatch:

- **GemPy/geological convention**: Z-up (Z = elevation)
- **Three.js convention**: Y-up (Y = vertical axis)

Test planes defined at constant Z levels (z=-200, -400, -600) were rendering as vertical slices instead of horizontal layers.

## Solution

### Coordinate Transformation

Applied the transform `[x, y, z] → [x, z, -y]` in `ModelViewer.tsx`:

1. **Vertex transformation**: Converts mesh vertices from GemPy coordinates to Three.js coordinates
2. **Center/extent calculation**: Updated to use transformed coordinates for proper camera positioning
3. **Grid helper**: Removed the 90° rotation hack since coordinates are now properly transformed

### Distinct Surface Colors

Added a 10-color palette to ensure each geological surface is visually distinguishable:
- Gold, Sea green, Steel blue, Peru, Dark orchid
- Light sea green, Crimson, Dark orange, Saddle brown, Slate blue

The legend now uses the same palette so colors match between the 3D view and the legend.

